### PR TITLE
Updated cron.d for non-interactive install

### DIFF
--- a/src/install_nquakesv.sh
+++ b/src/install_nquakesv.sh
@@ -139,6 +139,7 @@ defaultrcon=${nqrcon:-$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c12;echo)}
 defaultqtvpass=${nqqtvpassword:-$(< /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c12;echo)}
 defaultsearchoption=${nqsearchpak:-n}
 defaultsearchdir=${searchdir:-\~/}
+defaultaddcron=${addcron:-y}
 
 error() {
   printf "ERROR: %s\n" "$*"


### PR DESCRIPTION
Added the additional default value for "addcron" question at the end.  This is currently blocking non-interactive installation mode with a prompt at the end of the installation.