### PR TITLE
Preserve newlines when converting DOS to NIX at EOF

### DIFF
--- a/src/install_nquakesv.sh
+++ b/src/install_nquakesv.sh
@@ -430,7 +430,7 @@ nqnecho "* Removing distribution files..."
 # Convert DOS files to UNIX
 nqnecho "* Converting DOS files to UNIX..."
 for file in $(find ${directory} -iname "*.cfg" -or -iname "*.txt" -or -iname "*.sh" -or -iname "README"); do
-  [ -f "${file}" ] && sed -i 's/^M//g' ${file}
+  [ -f "${file}" ] && sed -i 's/\r$/\n/g' ${file}
 done
 nqecho "done"
 


### PR DESCRIPTION
Using literal "^M" instead of regex variable "\r" for Carriage Return was causing the letter M to be truncated. Also now changes CR to LF.